### PR TITLE
Korrektur in: Affine Koordinatensysteme | Sicher gewusst? | Frage 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,7 +462,7 @@ $$
 ****************************************
 
 Die Punkte $A$,$B$ und $X$ liegen auf der $x$-Achse eines Koordinatensystems, wobei $B$ und $X$ durch $A$ (Ursprung des affinen Koordinatensystems) getrennt sind. Es berechnet sich $$
-  TV(X,B,A)=(-1)\cdot)\cdot\frac{6}{2}=-3
+  TV(X,B,A)=(-1)\cdot\frac{6}{2}=-3
 $$
 
 ****************************************


### PR DESCRIPTION
TV(X,B,A)=(-1)\cdot)\cdot\frac{6}{2}=-3 

Schreibfehler:  "\cdot ))\cdot" 
Wird angezeigt wie folgt, in Klammern minus eins, mal klammer zu, mal sechs, durch zwei.